### PR TITLE
[ON-40364] expose the estimated delay ms AEC/AECM

### DIFF
--- a/base/checks.cc
+++ b/base/checks.cc
@@ -16,7 +16,7 @@
 #include <cstdio>
 #include <cstdlib>
 
-#if defined(__GLIBCXX__) && !defined(__UCLIBC__)
+#if defined(__GLIBCXX__) && !defined(__UCLIBC__) && defined(LIBON_NOT_DEFINED)
 #include <cxxabi.h>
 #include <execinfo.h>
 #endif
@@ -60,7 +60,7 @@ void PrintError(const char* format, ...) {
 // to get usable symbols on Linux. This is copied from V8. Chromium has a more
 // advanced stace trace system; also more difficult to copy.
 void DumpBacktrace() {
-#if defined(__GLIBCXX__) && !defined(__UCLIBC__)
+#if defined(__GLIBCXX__) && !defined(__UCLIBC__) && defined(LIBON_NOT_DEFINED)
   void* trace[100];
   int size = backtrace(trace, sizeof(trace) / sizeof(*trace));
   char** symbols = backtrace_symbols(trace, size);

--- a/base/helpers.cc
+++ b/base/helpers.cc
@@ -12,6 +12,7 @@
 
 #include <limits>
 #include <memory>
+#include <stdlib.h>
 
 #if defined(FEATURE_ENABLE_SSL)
 #include "webrtc/base/sslconfig.h"

--- a/modules/audio_processing/aec/aec_core.cc
+++ b/modules/audio_processing/aec/aec_core.cc
@@ -12,6 +12,7 @@
  * The core AEC algorithm, which is presented with time-aligned signals.
  */
 
+#include "mediastreamer2/msfilter.h"
 #include "webrtc/modules/audio_processing/aec/aec_core.h"
 
 #include <algorithm>
@@ -1378,7 +1379,9 @@ static void ProcessBlock(AecCore* aec) {
                                    abs_far_spectrum, PART_LEN1) == 0) {
       int delay_estimate = WebRtc_DelayEstimatorProcessFloat(
           aec->delay_estimator, abs_near_spectrum, PART_LEN1);
+      ms_debug("WebRtc_DelayEstimatorProcessFloat last[%d] delay[%d]", aec->libon_delay_estimate, delay_estimate);
       if (delay_estimate >= 0) {
+        aec->libon_delay_estimate=delay_estimate;
         // Update delay estimate buffer.
         aec->delay_histogram[delay_estimate]++;
         aec->num_delay_values++;
@@ -1514,7 +1517,7 @@ AecCore* WebRtcAec_CreateAec(int instance_count) {
   WebRtcAec_PartitionDelay = PartitionDelay;
   WebRtcAec_WindowData = WindowData;
 
-#if defined(WEBRTC_ARCH_X86_FAMILY)
+#if defined(WEBRTC_ARCH_X86_FAMILY) && defined(LIBON_NOT_DEFINED)
   if (WebRtc_GetCPUInfo(kSSE2)) {
     WebRtcAec_InitAec_SSE2();
   }
@@ -1524,7 +1527,9 @@ AecCore* WebRtcAec_CreateAec(int instance_count) {
   WebRtcAec_InitAec_mips();
 #endif
 
+#pragma message("***\n***\nWEBRTC_HAS_NEON ?\n***\n***")
 #if defined(WEBRTC_HAS_NEON)
+#pragma message("***\n***\nWEBRTC_HAS_NEON WebRtcAec_InitAec_neon()\n***\n***")
   WebRtcAec_InitAec_neon();
 #endif
 

--- a/modules/audio_processing/aec/aec_core.h
+++ b/modules/audio_processing/aec/aec_core.h
@@ -169,6 +169,8 @@ struct AecCore {
 
   int system_delay;  // Current system delay buffered in AEC.
 
+  int libon_delay_estimate; // Current delay estimate
+
   int mult;  // sampling frequency multiple
   int sampFreq = 16000;
   size_t num_bands;

--- a/modules/audio_processing/aec/aec_rdft.cc
+++ b/modules/audio_processing/aec/aec_rdft.cc
@@ -571,7 +571,7 @@ void aec_rdft_init(void) {
   cftfsub_128 = cftfsub_128_C;
   cftbsub_128 = cftbsub_128_C;
   bitrv2_128 = bitrv2_128_C;
-#if defined(WEBRTC_ARCH_X86_FAMILY)
+#if defined(WEBRTC_ARCH_X86_FAMILY_DISABE)
   if (WebRtc_GetCPUInfo(kSSE2)) {
     aec_rdft_init_sse2();
   }

--- a/modules/audio_processing/aec/echo_cancellation.cc
+++ b/modules/audio_processing/aec/echo_cancellation.cc
@@ -522,6 +522,12 @@ int WebRtcAec_GetDelayMetrics(void* handle,
   return 0;
 }
 
+
+int libon_WebRtcAec_GetDelayEstimate(void* handle) {
+  Aec* self = reinterpret_cast<Aec*>(handle);
+  return self->aec->libon_delay_estimate;
+}
+
 AecCore* WebRtcAec_aec_core(void* handle) {
   if (!handle) {
     return NULL;

--- a/modules/audio_processing/aec/echo_cancellation.h
+++ b/modules/audio_processing/aec/echo_cancellation.h
@@ -281,6 +281,9 @@ int WebRtcAec_GetDelayMetrics(void* handle,
                               int* std,
                               float* fraction_poor_delays);
 
+/* Libon: return the last delay estimate (binary spectrum match) in block of 8ms  */
+int libon_WebRtcAec_GetDelayEstimate(void* handle);
+
 // Returns a pointer to the low level AEC handle.
 //
 // Input:

--- a/modules/audio_processing/aecm/aecm_core.cc
+++ b/modules/audio_processing/aecm/aecm_core.cc
@@ -8,6 +8,8 @@
  *  be found in the AUTHORS file in the root of the source tree.
  */
 
+
+#include "mediastreamer2/msfilter.h"
 #include "webrtc/modules/audio_processing/aecm/aecm_core.h"
 
 #include <assert.h>
@@ -366,7 +368,8 @@ static void ResetAdaptiveChannelC(AecmCore* aecm) {
 
 // Initialize function pointers for ARM Neon platform.
 #if defined(WEBRTC_HAS_NEON)
-static void WebRtcAecm_InitNeon(void)
+#pragma message("WEBRTC_HAS_NEON: TRUE")
+void WebRtcAecm_InitNeon(void)
 {
   WebRtcAecm_StoreAdaptiveChannel = WebRtcAecm_StoreAdaptiveChannelNeon;
   WebRtcAecm_ResetAdaptiveChannel = WebRtcAecm_ResetAdaptiveChannelNeon;
@@ -738,6 +741,8 @@ void WebRtcAecm_CalcEnergies(AecmCore* aecm,
     aecm->nearLogEnergy[0] = LogOfEnergyInQ8(nearEner, aecm->dfaNoisyQDomain);
 
     WebRtcAecm_CalcLinearEnergies(aecm, far_spectrum, echoEst, &tmpFar, &tmpAdapt, &tmpStored);
+    ms_debug("WebRtcAecm_CalcLinearEnergies echoEst[%d] echo_energy_adapt[%d] echo_energy_stored[%d]" , *echoEst, tmpAdapt, tmpStored);
+    aecm->libon_echo_estimate = *echoEst;
 
     // Shift buffers
     memmove(aecm->echoAdaptLogEnergy + 1, aecm->echoAdaptLogEnergy,

--- a/modules/audio_processing/aecm/aecm_core.h
+++ b/modules/audio_processing/aecm/aecm_core.h
@@ -54,6 +54,8 @@ typedef struct {
     void* delay_estimator_farend;
     void* delay_estimator;
     uint16_t currentDelay;
+    int16_t libon_delay_estimate;
+    int32_t libon_echo_estimate;
     // Far end history variables
     // TODO(bjornv): Replace |far_history| with ring_buffer.
     uint16_t far_history[PART_LEN1 * MAX_DELAY];

--- a/modules/audio_processing/aecm/aecm_core_c.cc
+++ b/modules/audio_processing/aecm/aecm_core_c.cc
@@ -412,6 +412,9 @@ int WebRtcAecm_ProcessBlock(AecmCore* aecm,
     delay = aecm->fixedDelay;
   }
 
+  aecm->libon_delay_estimate = delay;
+
+
   // Get aligned far end spectrum
   far_spectrum_ptr = WebRtcAecm_AlignedFarend(aecm, &far_q, delay);
   zerosXBuf = (int16_t) far_q;

--- a/modules/audio_processing/aecm/echo_control_mobile.cc
+++ b/modules/audio_processing/aecm/echo_control_mobile.cc
@@ -9,6 +9,7 @@
  */
 
 #include "webrtc/modules/audio_processing/aecm/echo_control_mobile.h"
+#include <stdint.h>
 
 #ifdef AEC_DEBUG
 #include <stdio.h>
@@ -235,6 +236,16 @@ int32_t WebRtcAecm_BufferFarend(void *aecmInst, const int16_t *farend,
   WebRtc_WriteBuffer(aecm->farendBuf, farend, nrOfSamples);
 
   return 0;
+}
+
+int32_t libon_WebRtcAecm_GetEchoEstimate(void *aecmInst) {
+    AecMobile* aecm = static_cast<AecMobile*>(aecmInst);
+    return aecm->aecmCore->libon_echo_estimate;
+}
+
+int16_t libon_WebRtcAecm_GetDelayEstimate(void *aecmInst) {
+    AecMobile* aecm = static_cast<AecMobile*>(aecmInst);
+    return aecm->aecmCore->libon_delay_estimate;
 }
 
 int32_t WebRtcAecm_Process(void *aecmInst, const int16_t *nearendNoisy,

--- a/modules/audio_processing/aecm/echo_control_mobile.h
+++ b/modules/audio_processing/aecm/echo_control_mobile.h
@@ -39,6 +39,12 @@ typedef struct {
 extern "C" {
 #endif
 
+
+/* Libon: return the last delay estimate (binary spectrum match) in block of 8ms  */
+int16_t libon_WebRtcAecm_GetDelayEstimate(void* aecmInst);
+int32_t libon_WebRtcAecm_GetEchoEstimate(void* aecmInst);
+
+
 /*
  * Allocates the memory needed by the AECM. The memory needs to be
  * initialized separately using the WebRtcAecm_Init() function.


### PR DESCRIPTION
[ON-40364] expose the estimated echo AEC/AECM
- small modifications to build with Libon ms2
  adding missing unused define to compile for Libon

https://github.com/libon/libon-mswebrtc/pull/4
https://github.com/jchavanton/webrtc/pull/1
https://github.com/libon/libon-linphone/pull/106
https://github.com/libon/libon-mediastreamer2/pull/88
https://github.com/libon/libon-ortp/pull/64
